### PR TITLE
Include resources in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,6 @@ qtpy = ["qtpy>=2.0,<3"]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools.packages.find]
-include = ["qt_material_icons"]
-
 [tool.semantic_release]
 version_variable = "qt_material_icons/__init__.py:__version__"
 version_toml  = ["pyproject.toml:project.version"]


### PR DESCRIPTION
fix #3 

removing some lines in pyproject allowed resources folder to be rightly copied in the site-packages folder. You probably have to package it again and post it to pypi but then it weight almost 100MB... 

Can we think of a mechanism to actually build icons on the fly when they are needed?

Cheers